### PR TITLE
Ability to use multiple configuration instances for systemd service.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ netbsd-rc: hetzner_ddns.netbsd.rc
 systemd: hetzner_ddns.service
 	@mkdir -p $(prefix)/etc/systemd/system
 	@install -m 0644 -p hetzner_ddns.service $(prefix)/etc/systemd/system/hetzner_ddns.service
+	@install -m 0644 -p hetzner_ddns@.service $(prefix)/etc/systemd/system/hetzner_ddns@.service
 
 openrc: hetzner_ddns.init
 	@mkdir -p $(prefix)/etc/init.d
@@ -41,4 +42,5 @@ remove:
 		$(prefix)/usr/local/share/man/man1/hetzner_ddns.1.gz \
 		$(prefix)/usr/local/etc/rc.d/hetzner_ddns \
 		$(prefix)/etc/systemd/system/hetzner_ddns.service \
+		$(prefix)/etc/systemd/system/hetzner_ddns@.service \
 		$(prefix)/etc/init.d/hetzner_ddns

--- a/hetzner_ddns.sh
+++ b/hetzner_ddns.sh
@@ -2,6 +2,11 @@
 
 self='hetzner_ddns'
 
+if [[ ! -z "$1" ]]
+then
+    self="${self}.$1"
+fi
+
 # Read variabels from configuration file
 if test -G "/usr/local/etc/$self.conf"; then
     . "/usr/local/etc/$self.conf"

--- a/hetzner_ddns@.service
+++ b/hetzner_ddns@.service
@@ -1,0 +1,28 @@
+[Unit]
+Description=Hetzner Dynamic DNS for %I
+Documentation=man:hetzner_ddns(1)
+After=network.target
+
+[Service]
+Type=simple
+User=daemon
+Group=root
+ExecStartPre=/usr/bin/touch /var/log/hetzner_ddns.%i.log
+ExecStartPre=/usr/bin/chown daemon:root /var/log/hetzner_ddns.%i.log
+ExecStart=/usr/local/bin/hetzner_ddns %i
+Restart=always
+RestartSec=10
+
+PermissionsStartOnly=true
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=full
+ProtectHome=read-only
+ProtectControlGroups=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+MemoryDenyWriteExecute=yes
+LockPersonality=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The pull request is recreated for https://github.com/filiparag/hetzner_ddns/pull/1.

This is a simple change to allow the user to define multiple systemd service configuration instances for each domain. Basically, the user can create multiple configurations with the name formatted as hetzner_ddns.example.com.conf and start the corresponding systemd service like this: systemctl start hetzner_ddns@example.com.service

I didn't have the time to update the man page and markup documentation yet. If nobody does it, I might be able to send the changes for documentation too.

I also tested it with the current AUR package and multiple domains and it's working correctly. The older configuration mechanism is not changed so this change is backward compatible.