### PR TITLE
No net tools dependency on OpenWrt

### DIFF
--- a/release/OpenWrt/Makefile
+++ b/release/OpenWrt/Makefile
@@ -22,7 +22,7 @@ define Package/$(PKG_NAME)
 	SECTION:=net
 	CATEGORY:=Network
 	TITLE:=Hetzner Dynamic DNS Daemon
-	DEPENDS:=+jq +gawk +curl +net-tools
+	DEPENDS:=+jq +gawk +curl
 	PKGARCH:=all
 endef
 


### PR DESCRIPTION
As OpenWrt uses `busybox` the newly introduced `net-tools` dependency is not explicitly needed.
`ifconfig` and `netstat` as already available.