### PR TITLE
hetzner_ddns.sh: Replace `hostname` with `uname -n`

### DIFF
--- a/hetzner_ddns.sh
+++ b/hetzner_ddns.sh
@@ -35,7 +35,7 @@ create_log_file() {
 }
 
 test_dependencies() {
-    for d in awk curl cut getopts jq mkfifo mktemp netstat ifconfig sed sort uniq touch hostname cat tr wc; do
+    for d in awk curl cut getopts jq mkfifo mktemp netstat ifconfig sed sort uniq touch uname cat tr wc; do
         if ! command -v "$d" 1> /dev/null 2> /dev/null; then
             echo "Error: Missing dependency '$d'"
             return 1
@@ -537,7 +537,7 @@ update_record() {
                 \"records\": [
                     {
                         \"value\": \"$expected_value\",
-                        \"comment\": \"Managed by $program on $(hostname)\"
+                        \"comment\": \"Managed by $program on $(uname -n)\"
                     }
                 ]
             }" \


### PR DESCRIPTION
On OpenWrt, busybox is compiled without support for the `hostname` command, see openwrt/openwrt#11765. Using `uname -n` to get the current hostname instead removes an additional dependency.

Using `cat /proc/sys/kernel/hostname` might be even better, but I'm not sure if this exists on all supported BSDs.